### PR TITLE
Add a global default option and a page-specific option to show or hide the TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # gitbook-plugin-page-toc
 
-Add Table of Contents (TOC) to every page in your GitBook.
-
-It adds anchors link to headings inside the page as well.
+This plugin adds a table of contents (TOC) to each page in your Gitbook.
+You can set whether the TOC appears on all pages by default, and you can enable or disable the TOC on individual pages to override the default.
 
 ![](https://raw.githubusercontent.com/aleung/gitbook-plugin-page-toc/master/doc/screenshot-1.png)
 
@@ -11,11 +10,14 @@ It adds anchors link to headings inside the page as well.
 Add the plugin to your `book.json`:
 
 ``` json
-    {
-      "plugins": [ "page-toc" ],
-      "pluginsConfig": {
-      }
-    }
+{
+  "plugins": [ "page-toc" ],
+  "pluginsConfig": {
+     "selector": ".markdown-section h1, .markdown-section h2, .markdown-section h3, .markdown-section h4",
+     "position": "before-first",
+     "showByDefault": true
+  }
+}
 ```
 
 ## Configuration
@@ -27,6 +29,28 @@ Add the plugin to your `book.json`:
   - Allowed values:
     - `before-first` _(default)_ : Before the first heading
     - `top` : On top of the page
+- `showByDefault`: Whether to show the TOC on all pages by default.
+    Default value is `true`.
+
+## Use
+
+To show a TOC in one of your pages, either set the `showByDefault` parameter to `true` in your `book.json`, or add the front matter item `showToc: true` to the top of the Markdown file like this:
+```markdown
+---
+showToc: true
+---
+# My interesting page that has a TOC
+```
+
+If you have the `showByDefault` parameter set to `true` and you want to hide the TOC on a page, add the front matter item `showToc: false` to the top of the Markdown file like this:
+```markdown
+---
+showToc: false
+---
+# My interesting page that does not have a TOC
+```
+
+The page-specific front matter overrides the `showByDefault` parameter.
 
 ## CSS Customization
 

--- a/assets/page-toc.js
+++ b/assets/page-toc.js
@@ -2,6 +2,7 @@ require(['gitbook'], function(gitbook) {
 
     var selector;
     var position;
+    var showByDefault;
 
     anchors.options = {
         placement: 'left'
@@ -49,10 +50,9 @@ require(['gitbook'], function(gitbook) {
         anchors.removeAll();
         anchors.add(selector);
 
-        var showToc = document.body.querySelector('.showToc');
-        var hideToc = document.body.querySelector('.hideToc');
+        var showToc = gitbook.state.page.showToc;
 
-        if (anchors.elements.length > 1 && (showByDefault || showToc != null) && hideToc == null) {
+        if (anchors.elements.length > 1 && (showByDefault || showToc) && showToc != false) {
             var text, href, currentLevel;
             var prevLevel = 0;
             var nav = document.createElement('nav');

--- a/assets/page-toc.js
+++ b/assets/page-toc.js
@@ -10,6 +10,7 @@ require(['gitbook'], function(gitbook) {
     gitbook.events.bind('start', function(e, config) {
         selector = config['page-toc'].selector;
         position = config['page-toc'].position;
+        showByDefault = config['page-toc'].showByDefault;
     });
 
     gitbook.events.bind('page.change', function() {
@@ -48,7 +49,10 @@ require(['gitbook'], function(gitbook) {
         anchors.removeAll();
         anchors.add(selector);
 
-        if (anchors.elements.length > 1) {
+        var showToc = document.body.querySelector('.showToc');
+        var hideToc = document.body.querySelector('.hideToc');
+
+        if (anchors.elements.length > 1 && (showByDefault || showToc != null) && hideToc == null) {
             var text, href, currentLevel;
             var prevLevel = 0;
             var nav = document.createElement('nav');
@@ -75,4 +79,3 @@ require(['gitbook'], function(gitbook) {
     })
 
 });
-

--- a/index.js
+++ b/index.js
@@ -3,5 +3,15 @@ module.exports = {
     assets: "./assets",
     css: ["page-toc.css"],
     js: ["anchor-3.1.1.min.js","page-toc.js"]
+  },
+  hooks: {
+    "page:before": function(page) {
+      if (page['showToc']) {
+        page.content = '<div class="showToc"></div>\n\n' + page.content;
+      } else if (page['showToc'] == false) {
+        page.content = '<div class="hideToc"></div>\n\n' + page.content;
+      }
+      return page;
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,15 +3,5 @@ module.exports = {
     assets: "./assets",
     css: ["page-toc.css"],
     js: ["anchor-3.1.1.min.js","page-toc.js"]
-  },
-  hooks: {
-    "page:before": function(page) {
-      if (page['showToc']) {
-        page.content = '<div class="showToc"></div>\n\n' + page.content;
-      } else if (page['showToc'] == false) {
-        page.content = '<div class="hideToc"></div>\n\n' + page.content;
-      }
-      return page;
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
           "before-first",
           "top"
         ]
+      },
+      "showByDefault": {
+         "type": "boolean",
+         "default": true,
+         "title": "Whether to show the TOC on every page by default"
       }
     }
   },


### PR DESCRIPTION
This fixes #5.