### PR TITLE
add: position anchor `after-first`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Add the plugin to your `book.json`:
 - `position` : Position of TOC
   - Allowed values:
     - `before-first` _(default)_ : Before the first heading
+    - `after-first` : After the first heading
     - `top` : On top of the page
 - `showByDefault`: Whether to show the TOC on all pages by default.
   - Default:  `true`.

--- a/assets/page-toc.js
+++ b/assets/page-toc.js
@@ -70,6 +70,9 @@ require(['gitbook'], function(gitbook) {
             if (position === 'top') {
                 var section = document.body.querySelector('.markdown-section');
                 section.insertBefore(nav, section.firstChild);
+            } else if (position === 'after-first') {
+                var first = anchors.elements[0];
+                first.parentNode.insertBefore(nav, first.nextSibling);
             } else {
                 var first = anchors.elements[0];
                 first.parentNode.insertBefore(nav, first);

--- a/assets/page-toc.js
+++ b/assets/page-toc.js
@@ -67,14 +67,13 @@ require(['gitbook'], function(gitbook) {
                 prevLevel = currentLevel;
             }
 
+            var first = anchors.elements[0];
             if (position === 'top') {
                 var section = document.body.querySelector('.markdown-section');
                 section.insertBefore(nav, section.firstChild);
             } else if (position === 'after-first') {
-                var first = anchors.elements[0];
                 first.parentNode.insertBefore(nav, first.nextSibling);
             } else {
-                var first = anchors.elements[0];
                 first.parentNode.insertBefore(nav, first);
             }
         }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         ]
       },
       "showByDefault": {
-        "type": "boolean",
-        "default": true,
-        "title": "Whether to show the TOC on every page by default"
+         "type": "boolean",
+         "default": true,
+         "title": "Whether to show the TOC on every page by default"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitbook-plugin-page-toc",
+  "name": "gitbook-plugin-page-toc-af",
   "description": "Adds table of conents and anchors inside page",
   "main": "index.js",
   "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
         "title": "Position of TOC",
         "enum": [
           "before-first",
+          "after-first",
           "top"
         ]
       },
       "showByDefault": {
-         "type": "boolean",
-         "default": true,
-         "title": "Whether to show the TOC on every page by default"
+        "type": "boolean",
+        "default": true,
+        "title": "Whether to show the TOC on every page by default"
       }
     }
   },


### PR DESCRIPTION
Hello, Thank you for your nice plugin.
I want `after-first` toc position anchor because I want to make doc like below picture.

![screenshot_2018-10-02_22 55 49](https://user-images.githubusercontent.com/7391357/46353797-0241de80-c698-11e8-9a4f-1aa34db0c089.png)
